### PR TITLE
Issue #620: use viewreport cap for downloading student certs

### DIFF
--- a/view.php
+++ b/view.php
@@ -151,7 +151,7 @@ if (!$downloadown && !$downloadissue) {
     }
     echo $OUTPUT->footer($course);
     exit();
-} else if ($canreceive || $canmanage) { // Output to pdf.
+} else if ($canreceive || $canviewreport) { // Output to pdf.
     // Set the userid value of who we are downloading the certificate for.
     $userid = $USER->id;
     if ($downloadown) {


### PR DESCRIPTION
Port over the fix for this upstream issue and PR
https://github.com/mdjnelson/moodle-mod_customcert/issues/620
https://github.com/mdjnelson/moodle-mod_customcert/pull/621